### PR TITLE
Switch from using llvm_asm to asm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! A collection of useful utilities for running experiments.
 
-#![feature(llvm_asm)]
-
 pub mod linux4_4;
 pub mod resultarray;
 pub mod timing;

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,6 +1,6 @@
 //! Utilities for measuring time.
 
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, time::Duration, arch::asm};
 
 /// A trait for time sources. This allows methods to be generic over different ways of measuring
 /// time.
@@ -26,7 +26,7 @@ pub fn rdtsc() -> u64 {
     let lo: u32;
 
     unsafe {
-        llvm_asm!("rdtsc" : "={eax}"(lo), "={edx}"(hi));
+        asm!("rdtsc", out("eax") lo, out("edx") hi);
     }
 
     u64::from(lo) | (u64::from(hi) << 32)


### PR DESCRIPTION
The former is deprecated in newer versions of rustc